### PR TITLE
Questions activated for given time

### DIFF
--- a/izp/polls/models.py
+++ b/izp/polls/models.py
@@ -63,9 +63,11 @@ class Question(models.Model):
         and has not been deactivated yet.
         """
 
-        return self.activation_time and not self.deactivation_time
+        return ((self.activation_time and not self.deactivation_time)
+                or (self.activation_time
+                    and self.deactivation_time < timezone.now()))
 
-    def activate(self):
+    def activate(self, time=None):
         """
         Method activates the Question
         by setting activation time to current time.
@@ -73,6 +75,9 @@ class Question(models.Model):
 
         if self.is_available():
             self.activation_time = timezone.now()
+            if time:
+                self.deactivation_time = (timezone.now()
+                                          + timezone.timedelta(minutes=time))
             self.save()
 
     def deactivate(self):

--- a/izp/polls/models.py
+++ b/izp/polls/models.py
@@ -65,19 +65,22 @@ class Question(models.Model):
 
         return ((self.activation_time and not self.deactivation_time)
                 or (self.activation_time
-                    and self.deactivation_time < timezone.now()))
+                    and self.deactivation_time > timezone.now()))
 
-    def activate(self, time=None):
+    def activate(self, minutes=None):
         """
         Method activates the Question
         by setting activation time to current time.
+        If time is specified,
+        the Question will be active for that many minutes.
         """
 
         if self.is_available():
             self.activation_time = timezone.now()
-            if time:
-                self.deactivation_time = (timezone.now()
-                                          + timezone.timedelta(minutes=time))
+            if minutes:
+                self.deactivation_time =\
+                    (self.activation_time
+                     + timezone.timedelta(minutes=minutes))
             self.save()
 
     def deactivate(self):

--- a/izp/polls/templates/polls/poll_detail.html
+++ b/izp/polls/templates/polls/poll_detail.html
@@ -45,17 +45,20 @@
 
             {% if user.is_superuser %}
             <td>
-                {% if question.is_available %}
-                <form action="{% url 'polls:activate_question' question.id %}" method="post">
+               {% if question.is_available %}
+               <form action="{% url 'polls:activate_question' question.id %}" method="post">
                   {% csrf_token %}
                   <button class="btn btn-success">Rozpocznij</button>
-                </form>
-                {% elif question.is_active %}
-                <form action="{% url 'polls:deactivate_question' question.id %}" method="post">
+                  na
+                  <input name="time" type="text" size="4">
+                  min
+               </form>
+               {% elif question.is_active %}
+               <form action="{% url 'polls:deactivate_question' question.id %}" method="post">
                   {% csrf_token %}
                   <button class="btn btn-danger">Zakończ</button>
-                </form>
-                {% endif %}
+               </form>
+               {% endif %}
             </td>
             {% endif %}
 

--- a/izp/polls/tests/test_models.py
+++ b/izp/polls/tests/test_models.py
@@ -107,10 +107,7 @@ class QuestionTests(TestCase):
     def test_is_active_given_deactivation_time(self):
         question = Question.objects.get(question_text="test-question")
         self.assertFalse(question.is_active())
-        question.activate()
-        self.assertTrue(question.is_active())
-        question.deactivation_time = (timezone.now()
-                                      + timezone.timedelta(seconds=10))
+        question.activate(minutes=1)
         self.assertTrue(question.is_active())
         question.deactivate()
         self.assertFalse(question.is_active())

--- a/izp/polls/tests/test_models.py
+++ b/izp/polls/tests/test_models.py
@@ -91,56 +91,34 @@ class QuestionTests(TestCase):
     def test_is_available(self):
         question = Question.objects.get(question_text="test-question")
         self.assertTrue(question.is_available())
-        question.activation_time = timezone.now()
+        question.activate()
         self.assertFalse(question.is_available())
-        question.deactivation_time = timezone.now()
+        question.deactivate()
         self.assertFalse(question.is_available())
 
     def test_is_active_no_deactivation_time(self):
         question = Question.objects.get(question_text="test-question")
         self.assertFalse(question.is_active())
-        question.activation_time = timezone.now()
+        question.activate()
         self.assertTrue(question.is_active())
-        question.deactivation_time = timezone.now()
+        question.deactivate()
         self.assertFalse(question.is_active())
 
     def test_is_active_given_deactivation_time(self):
         question = Question.objects.get(question_text="test-question")
         self.assertFalse(question.is_active())
-        question.activation_time = timezone.now()
+        question.activate()
         self.assertTrue(question.is_active())
         question.deactivation_time = (timezone.now()
                                       + timezone.timedelta(seconds=10))
         self.assertTrue(question.is_active())
-        question.deactivation_time = timezone.now()
-        self.assertFalse(question.is_active())
-
-    def test_activate_forever(self):
-        question = Question.objects.get(question_text="test-question")
-        question.activate()
-        self.assertAlmostEqual(timezone.now(), question.activation_time,
-                               delta=timezone.timedelta(seconds=1))
-
-    def test_activate_for_given_minutes(self):
-        question = Question.objects.get(question_text="test-question")
-        question.activate(minutes=10)
-        self.assertAlmostEqual(timezone.now(), question.activation_time,
-                               delta=timezone.timedelta(seconds=1))
-        self.assertAlmostEqual(timezone.now() + timezone.timedelta(minutes=10),
-                               question.deactivation_time,
-                               delta=timezone.timedelta(seconds=1))
-
-    def test_deactivate_active_question(self):
-        question = Question.objects.get(question_text="test-question")
-        question.activate()
         question.deactivate()
-        self.assertAlmostEqual(timezone.now(), question.deactivation_time,
-                               delta=timezone.timedelta(seconds=1))
+        self.assertFalse(question.is_active())
 
     def test_try_to_deativate_inactive_question(self):
         question = Question.objects.get(question_text="test-question")
         question.deactivate()
-        self.assertFalse(question.deactivation_time)
+        self.assertIsNone(question.deactivation_time)
 
 
 class OpenQuestionTests(TestCase):

--- a/izp/polls/views.py
+++ b/izp/polls/views.py
@@ -232,6 +232,16 @@ def activate_question(request, question_id):
                         if question.is_active()]
     is_session = 'poll' + str(question.poll.id) in request.session
 
+    if active_questions:
+        return render(request, 'polls/poll_detail.html',
+                      {'poll': question.poll,
+                       'questions_list': Question.objects.filter(
+                           poll__exact=question.poll).order_by(
+                           '-activation_time'),
+                       'is_session': is_session,
+                       'error': "Aktywne inne głosowanie"
+                       })
+
     if time:
         try:
             time = int(time)
@@ -244,18 +254,9 @@ def activate_question(request, question_id):
                            'is_session': is_session,
                            'error': "Zły format czasu"
                            })
-
-    if active_questions:
-        return render(request, 'polls/poll_detail.html',
-                      {'poll': question.poll,
-                       'questions_list': Question.objects.filter(
-                           poll__exact=question.poll).order_by(
-                           '-activation_time'),
-                       'is_session': is_session,
-                       'error': "Aktywne inne głosowanie"
-                       })
-
-    question.activate(time)
+        question.activate(time)
+    else:
+        question.activate()
 
     return HttpResponseRedirect(reverse('polls:poll_detail',
                                         args=(question.poll.id,)))


### PR DESCRIPTION
Changes:
- added text input for minutes next to activate/deactivate buttons in _poll detail view_
- leaving blank input results in question activated forever (until manual deactivation)
- added tests for _Question_ class methods